### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,30 +2,31 @@ schemaVersion: 2.1.0
 metadata:
   name: react
 components:
-  - name: nodejs
+  - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      memoryLimit: 1G
       endpoints:
         - exposure: public
           name: nodejs
           protocol: http
           targetPort: 4100
-      memoryLimit: 1G
-      mountSources: true
+
 commands:
-  - id: install
+  - id: install-dependencies
     exec:
       label: "Install all required dependencies"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/nodejs-react-redux
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
       commandLine: "npm install"
       group:
         kind: build
-  - id: start
+
+  - id: start-application
     exec:
       label: "Start the local server"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/nodejs-react-redux
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
       commandLine: "npm start"
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
