### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -9,7 +9,7 @@ components:
       endpoints:
         - exposure: public
           name: nodejs
-          protocol: http
+          protocol: https
           targetPort: 4100
 
 commands:


### PR DESCRIPTION
chore: use https protocol in endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-11_49_45](https://github.com/che-samples/nodejs-react-redux/assets/1271546/29ba80b9-d3ce-4951-aa4b-1103cb155332)

Related issue: https://issues.redhat.com/browse/CRW-5377