### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: react
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-16_10_36](https://github.com/che-samples/nodejs-react-redux/assets/1271546/df5fd437-98cf-4cf4-97c4-89fd89382836)

Related issue: https://github.com/eclipse/che/issues/21985

